### PR TITLE
build: fix relative path to dependency

### DIFF
--- a/OktaPS.build.ps1
+++ b/OktaPS.build.ps1
@@ -234,7 +234,9 @@ task DownloadDependencies {
 
     # find psm1
     If($environment -ne "Install") {
-        $nestedModules = Get-ChildItem -Path $pwshModuleFolder -Filter *.psm1 -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
+        $nestedModules = Get-ChildItem -Path $pwshModuleFolder -Filter *.psm1 -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+            $_.FullName.Substring($outputFolder.Length + 1)
+        }
         If($nestedModules.Count -gt 0) {
             Write-Host -NoNewLine "     Adding nested modules to manifest" 
             Update-ModuleManifest -Path $outputManifestPath -NestedModules $nestedModules


### PR DESCRIPTION
Minor fix to bug that was introduced in previous PR which referenced nested modules with absolute paths instead of relative paths. Users could not import the module on their machines, they would get an error `Import-Module: The given assembly name was invalid.`